### PR TITLE
Fix train url typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@ __pycache__/
 *~
 .eggs
 
-# ignore the default output folder
+# ignore the default input and output folder
 output/
+input/
 
 # ingnore big input file
 data/atcocodes-bus.csv

--- a/hypercat_builder/hypercat_builder.py
+++ b/hypercat_builder/hypercat_builder.py
@@ -90,10 +90,10 @@ class HypercatBuilder():
 
     return r
 
-  def build_catalogue_header(self, catalogue_type, index): 
+  def build_catalogue_header(self, catalogue_type, index):
     """Generates a live and timetable catalogue header.
     If the current catalogue being generated is of type 'bus' or the
-    catalogue index is greater than 1 the description value will  
+    catalogue index is greater than 1 the description value will
     include the catalogue index."""
 
     if catalogue_type == "bus" or index > 1 :
@@ -124,7 +124,7 @@ class HypercatBuilder():
 
     # create new hypercat catalogue for live items
     live_h, timetable_h = self.build_catalogue_header(catalogue_type, index)
-    
+
     # loop flag
     loop_again = False
 
@@ -147,7 +147,7 @@ class HypercatBuilder():
           if catalogue_type == 'train':
 
             live_r = self.build_hcitem_station(row, 'live')
-            live_h.addItem(live_r, '{:s}v3/uk/train/station/{:s}/live.json'.format(self.base_url, row[5]))
+            live_h.addItem(live_r, '{:s}/v3/uk/train/station/{:s}/live.json'.format(self.base_url, row[5]))
 
             timetable_r = self.build_hcitem_station(row, 'timetable')
             timetable_h.addItem(timetable_r, '{:s}/v3/uk/train/station/{:s}/timetable.json'.format(self.base_url, row[5]))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="HypercatBuilder",
 
     # Version number (initial):
-    version="0.1.2",
+    version="0.1.3",
 
     # Application author details:
     author="Thingful",


### PR DESCRIPTION
- add missing forward slash to live trains items `href` attribute 
